### PR TITLE
Parameterise branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,26 @@ sudo dpkg -i ../<deb name>
 ### Logging
 
 The NMOS software installed on both guests will log into the /var/log/nmos.log. SSH into the guests as detailed above to view these logs.
+
+### Using alternative NMOS branches
+
+The joint RI allows the user to set which branches of each of the NMOS repositories will be used when provisioning. The branches are set in environment variables on the host before the VM is provisioned. This is primarily intended for use in automated testing.
+
+The environment variables to be set are as follows:
+
+```
+NMOS_RI_COMMON_BRANCH
+NMOS_RI_MDNS_BRIDGE_BRANCH
+NMOS_RI_REVERSE_PROXY_BRANCH
+NMOS_RI_NODE_BRANCH
+NMOS_RI_QUERY_BRANCH
+NMOS_RI_REGISTRATION_BRANCH
+NMOS_RI_CONNECTION_BRANCH
+```
+
+For example, the RI may be configured to use the "dev" branch of the reverse proxy as follows:
+
+```
+export NMOS_RI_REVERSE_PROXY_BRANCH=dev
+vagrant up
+```

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -18,6 +18,19 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  repos = ["COMMON", "MDNS_BRIDGE", "REVERSE_PROXY", "NODE", "QUERY", "REGISTRATION", "CONNECTION"]
+
+  args = Array.new
+  repos.each { |repo|
+    if ENV["NMOS_RI_" + repo + "_BRANCH"]
+      branch = ENV["NMOS_RI_" + repo + "_BRANCH"]
+      puts "Using " + repo + " branch " + branch
+    else
+      branch = "master"
+    end
+    args.push(branch)
+  }
+ 
   config.vm.define "regquery" do |regquery|	
 	regquery.vm.hostname = "regquery"
  	regquery.vm.box = "bento/ubuntu-16.04"
@@ -28,7 +41,7 @@ Vagrant.configure("2") do |config|
   	regquery.vm.network "private_network", type: "dhcp"
         regquery.vm.network "forwarded_port", type: "dhcp", guest: 80, host: 8082
 	regquery.vm.synced_folder "../", "/vagrant-root"
-  	regquery.vm.provision :shell, path: "provision_regquery.sh"
+  	regquery.vm.provision :shell, path: "provision_regquery.sh", args: args
   end
 
   config.vm.define "node" do |node|
@@ -43,7 +56,7 @@ Vagrant.configure("2") do |config|
         node.vm.network "forwarded_port", type: "dhcp", guest: 8858, host: 8858
         node.vm.network "forwarded_port", type: "dhcp", guest: 8860, host: 8860
 	node.vm.synced_folder "../", "/vagrant-root"
-  	node.vm.provision :shell, path: "provision_node.sh"
+  	node.vm.provision :shell, path: "provision_node.sh", args: args
   end
 end
 

--- a/vagrant/provision_node.sh
+++ b/vagrant/provision_node.sh
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+COMMON_BRANCH=$1
+MDNS_BRIDGE_BRANCH=$2
+REVERSE_PROXY_BRANCH=$3
+NODE_BRANCH=$4
+CONNECTION_BRANCH=$7
+
 export DEBIAN_FRONTEND=noninteractive
 APT_TOOL='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
 
@@ -38,16 +44,19 @@ git clone https://github.com/bbc/nmos-mdns-bridge.git
 git clone https://github.com/bbc/nmos-device-connection-management-ri.git
 
 cd /home/vagrant/nmos-common
+git checkout $COMMON_BRANCH
 pip install -e . --process-dependency-links
 install -m 666 /dev/null /var/log/nmos.log
 
 cd /home/vagrant/nmos-reverse-proxy
+git checkout $REVERSE_PROXY_BRANCH
 mk-build-deps --install debian/control --tool "$APT_TOOL"
 make deb
 dpkg -i ../ips-reverseproxy-common_*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-mdns-bridge
+git checkout $MDNS_BRIDGE_BRANCH
 make dsc
 mk-build-deps --install deb_dist/mdnsbridge_*.dsc --tool "$APT_TOOL"
 make deb
@@ -55,6 +64,7 @@ dpkg -i dist/python-mdnsbridge_*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-node
+git checkout $NODE_BRANCH
 make dsc
 mk-build-deps --install deb_dist/nodefacade_*.dsc --tool "$APT_TOOL"
 make deb
@@ -62,6 +72,7 @@ dpkg -i dist/python-nodefacade_*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-device-connection-management-ri
+git checkout $CONNECTION_BRANCH
 mk-build-deps --install debian/control --tool "$APT_TOOL"
 make deb
 dpkg -i ../python-connectionmanagement_*_all.deb

--- a/vagrant/provision_regquery.sh
+++ b/vagrant/provision_regquery.sh
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+COMMON_BRANCH=$1
+MDNS_BRIDGE_BRANCH=$2
+REVERSE_PROXY_BRANCH=$3
+QUERY_BRANCH=$5
+REGISTRATION_BRANCH=$6
+
 export DEBIAN_FRONTEND=noninteractive
 APT_TOOL='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
 
@@ -39,16 +45,19 @@ git clone --verbose https://github.com/bbc/nmos-registration.git
 git clone --verbose https://github.com/bbc/nmos-mdns-bridge.git
 
 cd /home/vagrant/nmos-common
+git checkout $COMMON_BRANCH
 pip install -e . --process-dependency-links
 install -m 666 /dev/null /var/log/nmos.log
 
 cd /home/vagrant/nmos-reverse-proxy
+git checkout $REVERSE_PROXY_BRANCH
 mk-build-deps --install debian/control --tool "$APT_TOOL"
 make deb
 dpkg -i ../ips-reverseproxy-common_*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-mdns-bridge
+git checkout $MDNS_BRIDGE_BRANCH
 make dsc
 mk-build-deps --install deb_dist/mdnsbridge_*.dsc --tool "$APT_TOOL"
 make deb
@@ -56,6 +65,7 @@ dpkg -i dist/python-mdnsbridge_*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-registration
+git checkout $REGISTRATION_BRANCH
 make dsc
 mk-build-deps --install deb_dist/registryaggregator_*.dsc --tool "$APT_TOOL"
 make deb
@@ -63,6 +73,7 @@ dpkg -i dist/python-registryaggregator_*.*_all.deb
 sudo apt-get -f -y install
 
 cd /home/vagrant/nmos-query
+git checkout $QUERY_BRANCH
 make dsc
 mk-build-deps --install deb_dist/registryquery_*.dsc --tool "$APT_TOOL"
 make deb


### PR DESCRIPTION
This allows the branch used for each of the nmos libraries/apps to be specified using environment variables on the host before provisioning. See updated README for details. This is to facilitate use of the RI in integration testing on Jenkins.