### PR TITLE
Temporary fix to remove dependancy on Ansible version 2.8.

### DIFF
--- a/vagrant/provisioning/roles/nmos-connectionmanagement-ui/tasks/main.yml
+++ b/vagrant/provisioning/roles/nmos-connectionmanagement-ui/tasks/main.yml
@@ -3,10 +3,7 @@
 # description: Install NMOS connection management UI
 
 - name: Copy share
-  copy:
-    src: /home/vagrant/connectionmanagement/share/ipp-connectionmanagement
-    dest: /usr/share
-    remote_src: yes
+  command: cp -r /home/vagrant/connectionmanagement/share/ipp-connectionmanagement /usr/share
 
 - name: Copy site
   copy:


### PR DESCRIPTION
By using copy command instead of copy module to perform recursive copy.