### PR TITLE
Add Testing Tool VM and call API to execute tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 stage ("Run Integration Tests") {
                     steps {
                         bbcVagrantFindPorts(vagrantDir: "vagrant")
-                        sh 'python3 -m unittest -v discover'
+                        sh 'python3 -m unittest discover -v'
                         script {
                             env.int_result = "SUCCESS"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,11 @@ pipeline {
                         }
                     }
                 }
+                stage ("Analyse XML / JUnit files") {
+                    steps {
+                        junit '*.xml'
+                    }
+                }
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                     steps {
                         script {
                             env.int_result = "FAILURE"
+                            env.NMOS_RI_TESTING_BRANCH = "dannym-api"
                         }
                         bbcGithubNotify(context: "tests/integration", status: "PENDING")
                         dir ('vagrant') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
                         script {
                             env.int_result = "FAILURE"
                             env.NMOS_RI_TESTING_BRANCH = "dannym-api"
+                            env.NMOS_RI_COMMON_BRANCH = "jamesg-consistent-iface-selection"
                         }
                         bbcGithubNotify(context: "tests/integration", status: "PENDING")
                         dir ('vagrant') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,9 @@ pipeline {
                         }
                     }
                 }
-                stage ("Analyse XML / JUnit files") {
+                stage ("Analyse JUnit files") {
                     steps {
-                        junit '*.xml'
+                        junit 'tests/*.xml'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 stage ("Run Integration Tests") {
                     steps {
                         bbcVagrantFindPorts(vagrantDir: "vagrant")
-                        sh 'python3 -m unittest discover'
+                        sh 'python3 -m unittest -v discover'
                         script {
                             env.int_result = "SUCCESS"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
                         script {
                             env.int_result = "FAILURE"
                             env.NMOS_RI_TESTING_BRANCH = "dannym-api"
-                            env.NMOS_RI_COMMON_BRANCH = "jamesg-consistent-iface-selection"
                         }
                         bbcGithubNotify(context: "tests/integration", status: "PENDING")
                         dir ('vagrant') {

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Introduction
 
-This repository contains a Vagrant provisioning to build 3 virtual machines:
+This repository contains a Vagrant provisioning to build 4 virtual machines:
 * IS-04/05 node
 * IS-04 registry
 * BCP-003-02 Authorisation Server
+* NMOS Testing Tool
 
 The node VM will also present a user interface for interacting with the APIs, and another which allows senders and receivers to be added to a "mock driver". This mock driver takes the place of the interface that would normally exist between the APIs and a sender or receiver, and allows the user to add mock up senders or receivers to the Connection Management and Node APIs. Note that the VM does not contain any actual RTP senders or receivers - you cannot produce media streams using this software.
 
@@ -23,11 +24,13 @@ For the best experience:
 pip install ansible
 ```
 
-The Node VM will bind to three host machine ports: 8884 to present the APIs themselves, 8858 to present the mock driver user interfaces and 8859 to present the IS-05 API user interface. 
+The Node VM will bind to three host machine ports: 8884 to present the APIs themselves, 8858 to present the mock driver user interfaces and 8860 to present the IS-05 API user interface.
 
-The Registration and Query machine will present its APIs on port 8882. 
+The Registration and Query machine will present its APIs on port 8882.
 
-The Authorisation Server will present its APIs on port 8886. 
+The Authorisation Server will present its APIs on port 8886.
+
+The testing tool will present itself on port 8888.
 
 If these ports are already in use on the host machine the bindings may be changed in the Vagrant file.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ vagrant ssh regquery
 vagrant ssh auth
 ```
 
+```
+vagrant ssh testing
+```
+
 The directories cloned down during setup are found in the home directory, but have root permissions. As such any operations on them require root privilidges. Software in the repositories may be built using:
 
 ```
@@ -163,6 +167,7 @@ NMOS_RI_QUERY_BRANCH
 NMOS_RI_REGISTRATION_BRANCH
 NMOS_RI_CONNECTION_BRANCH
 NMOS_RI_AUTH_BRANCH
+NMOS_RI_TESTING_BRANCH
 ```
 
 For example, the RI may be configured to use the "dev" branch of the reverse proxy as follows:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,11 +245,12 @@ class TestingIntegrationTests(unittest.TestCase):
 
     def checkResults(self, response):
         for result in response.json()["results"]:
-            self.assertNotEqual(
-                result["state"].lower(),
-                "fail",
-                "failed on test: {} - {}".format(result["name"], result["detail"])
-            )
+            with self.subTest(test=result["name"]):
+                self.assertNotEqual(
+                    result["state"].lower(),
+                    "fail",
+                    "failed on test: {} - {}".format(result["name"], result["detail"])
+                )
 
     def test_tool_up(self):
         msg = "Could not find testing tool running"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,7 @@ DEFAULT_PORTS = {
         '5000': '8888'
     }
 }
-# Default Vagrant internal IP aaddresses (should match Vagrant file!)
+# Default Vagrant internal IP addresses (should match Vagrant file!)
 DEFAULT_IP = {
     "regquery": "172.28.128.2",
     "node": "172.28.128.4",
@@ -193,7 +193,7 @@ class TestingIntegrationTests(unittest.TestCase):
         self.assertEqual(
             r.status_code,
             status_code,
-            msg + ". Path: {}, Port: {}. Repsonse: {}".format(path, port, r.text)
+            msg + ". Path: {}, Port: {}. Response: {}".format(path, port, r.text)
         )
         return r
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,18 +6,15 @@ import json
 # Default Vagrant port mappings (should match Vagrant file!)
 DEFAULT_PORTS = {
     "regquery": {
-        '80': '8882',
-        '22': '2222'
+        '80': '8882'
     },
     "node": {
         '80': '8884',
         '8858': '8858',
-        '8860': '8860',
-        '22': '2222'
+        '8860': '8860'
     },
     "auth": {
-        '80': '8886',
-        '22': '2222'
+        '80': '8886'
     },
     "testing": {
         '5000': '8888'
@@ -25,10 +22,10 @@ DEFAULT_PORTS = {
 }
 # Default Vagrant internal IP addresses (should match Vagrant file!)
 DEFAULT_IP = {
-    "regquery": "172.28.128.2",
-    "node": "172.28.128.4",
-    "auth": "172.28.128.6",
-    "testing": "172.28.128.8"
+    "regquery": "172.28.128.102",
+    "node": "172.28.128.104",
+    "auth": "172.28.128.106",
+    "testing": "172.28.128.108"
 }
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -289,7 +289,8 @@ class TestingIntegrationTests(unittest.TestCase):
             "suite": "IS-04-02",
             "host": [self.ipAddr["regquery"], self.ipAddr["regquery"]],
             "port": ['80', '80'],
-            "version": ['v1.2', 'v1.2']
+            "version": ['v1.2', 'v1.2'],
+            "ignore": ["test_27", "test_28"]
         }
         self.run_vagrant_command("vagrant up regquery")
         resp = self.runTest(body)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -238,7 +238,7 @@ class TestingIntegrationTests(unittest.TestCase):
             "suite": "IS-04-01",
             "host": [self.ipAddr["node"]],
             "port": ['80'],
-            "version": ["v1.0"]
+            "version": ["v1.2"]
         }
         resp = self.runTest(body)
         self.checkResults(resp)
@@ -248,7 +248,7 @@ class TestingIntegrationTests(unittest.TestCase):
             "suite": "IS-04-02",
             "host": [self.ipAddr["regquery"], self.ipAddr["regquery"]],
             "port": ['80', '80'],
-            "version": ['v1.0', 'v1.0']
+            "version": ['v1.2', 'v1.2']
         }
         resp = self.runTest(body)
         self.checkResults(resp)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,9 @@ DEFAULT_PORTS = {
     "auth": {
         '80': '8886',
         '22': '2222'
+    },
+    "testing": {
+        '5000': '5000'
     }
 }
 
@@ -29,7 +32,7 @@ class NodeIntegrationTests(unittest.TestCase):
         try:
             with open("vagrantPorts.json", "r") as f:
                 toReturn = json.load(f)
-        except:
+        except Exception:
             print("Did not find vagrantPorts.json in current directory, using default ports")
             toReturn = DEFAULT_PORTS
         return toReturn
@@ -78,7 +81,7 @@ class RegQueryIntegrationTests(unittest.TestCase):
         try:
             with open("vagrantPorts.json", "r") as f:
                 toReturn = json.load(f)
-        except:
+        except Exception:
             print("Did not find vagrantPorts.json in current directory, using default ports")
             toReturn = DEFAULT_PORTS
         return toReturn
@@ -122,6 +125,7 @@ class RegQueryIntegrationTests(unittest.TestCase):
         r = requests.get("http://localhost:{}{}".format(self.apiPort, "/x-nmos/query/v1.2/nodes"))
         self.assertEqual(len(r.json()), 1, msg)
 
+
 class AuthIntegrationTests(unittest.TestCase):
 
     @classmethod
@@ -129,7 +133,7 @@ class AuthIntegrationTests(unittest.TestCase):
         try:
             with open("vagrantPorts.json", "r") as f:
                 toReturn = json.load(f)
-        except:
+        except Exception:
             print("Did not find vagrantPorts.json in current directory, using default ports")
             toReturn = DEFAULT_PORTS
         return toReturn
@@ -155,3 +159,30 @@ class AuthIntegrationTests(unittest.TestCase):
     def test_auth_api_up(self):
         msg = "Could not find Auth API"
         self.checkUp('/x-nmos/auth/', self.apiPort, msg)
+
+
+class TestingIntegrationTests(unittest.TestCase):
+
+    @classmethod
+    def loadPorts(cls):
+        try:
+            with open("vagrantPorts.json", "r") as f:
+                toReturn = json.load(f)
+        except Exception:
+            print("Did not find vagrantPorts.json in current directory, using default ports")
+            toReturn = DEFAULT_PORTS
+        return toReturn
+
+    @classmethod
+    def setUpClass(cls):
+        ports = cls.loadPorts()
+        print(ports)
+        cls.apiPort = ports['testing']['5000']
+
+    def checkUp(self, path, port, msg):
+        r = requests.get("http://localhost:{}{}".format(port, path))
+        self.assertEqual(r.status_code, 200, msg)
+
+    def test_tool_up(self):
+        msg = "Could not find testing tool running"
+        self.checkUp('/', self.apiPort, msg)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -309,9 +309,9 @@ class TestingIntegrationTests(unittest.TestCase):
     def test_run_is05_02_tests(self):
         body = {
             "suite": "IS-05-02",
-            "host": [self.ipAddr["node"]],
-            "port": ['80'],
-            "version": ["v1.0"]
+            "host": [self.ipAddr["node"], self.ipAddr["node"]],
+            "port": ['80', '80'],
+            "version": ["v1.2", "v1.0"]
         }
         resp = self.runTest(body)
         self.checkResults(resp)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -234,7 +234,7 @@ class TestingIntegrationTests(unittest.TestCase):
                 data_format = output_name
                 output_name = "{}-on-{}".format(body["suite"], body["host"][0])
             if data_format.lower() in ["json", "xml"]:
-                with open('{}.{}'.format(output_name, data_format), "w+") as f:
+                with open('tests/{}.{}'.format(output_name, data_format), "w+") as f:
                     if data_format == "xml":
                         f.write(response.text)
                     else:
@@ -298,7 +298,8 @@ class TestingIntegrationTests(unittest.TestCase):
             "suite": "IS-04-01",
             "host": [self.ipAddr["node"]],
             "port": ['80'],
-            "version": ["v1.2"]
+            "version": ["v1.2"],
+            "output": "xml"
         }
         # Power down Regquery Node to allow Node instance to register with the Testing Tool's Mock Registries
         self.run_vagrant_command("vagrant halt regquery")
@@ -311,7 +312,8 @@ class TestingIntegrationTests(unittest.TestCase):
             "host": [self.ipAddr["regquery"], self.ipAddr["regquery"]],
             "port": ['80', '80'],
             "version": ['v1.2', 'v1.2'],
-            "ignore": ["test_27", "test_28"]
+            "ignore": ["test_27", "test_28"],
+            "output": "xml"
         }
         self.run_vagrant_command("vagrant up regquery")
         resp = self.runTest(body)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -296,7 +296,7 @@ class TestingIntegrationTests(unittest.TestCase):
         resp = self.runTest(body)
         self.checkResults(resp)
 
-    def test_run_is05_tests(self):
+    def test_run_is05_01_tests(self):
         body = {
             "suite": "IS-05-01",
             "host": [self.ipAddr["node"]],
@@ -305,4 +305,13 @@ class TestingIntegrationTests(unittest.TestCase):
         }
         resp = self.runTest(body)
         self.checkResults(resp)
+
+    def test_run_is05_02_tests(self):
+        body = {
+            "suite": "IS-05-02",
+            "host": [self.ipAddr["node"]],
+            "port": ['80'],
+            "version": ["v1.0"]
+        }
+        resp = self.runTest(body)
         self.checkResults(resp)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -305,15 +305,4 @@ class TestingIntegrationTests(unittest.TestCase):
         }
         resp = self.runTest(body)
         self.checkResults(resp)
-
-    def test_run_is10_tests(self):
-        # Enable HTTPS must be enabled to successfully run IS-10 Tests
-        self.changeConfig("ENABLE_HTTPS", True)
-        body = {
-            "suite": "IS-10-01",
-            "host": [self.ipAddr["auth"]],
-            "port": ['80'],
-            "version": ["v1.0"]
-        }
-        resp = self.runTest(body)
         self.checkResults(resp)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    testing.vm.network "private_network", ip: "172.28.128.8"
+    testing.vm.network "private_network", ip: "172.28.128.108"
     testing.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
     testing.vm.synced_folder "../", "/vagrant-root"
     testing.vm.boot_timeout = 600
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    regquery.vm.network "private_network", ip: "172.28.128.2"
+    regquery.vm.network "private_network", ip: "172.28.128.102"
     regquery.vm.network "forwarded_port", guest: 80, host: 8882, auto_correct: true
     regquery.vm.synced_folder "../", "/vagrant-root"
     regquery.vm.boot_timeout = 600
@@ -64,7 +64,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    node.vm.network "private_network", ip: "172.28.128.4"
+    node.vm.network "private_network", ip: "172.28.128.104"
     node.vm.network "forwarded_port", guest: 80, host: 8884, auto_correct: true
     node.vm.network "forwarded_port", guest: 8858, host: 8858, auto_correct: true
     node.vm.network "forwarded_port", guest: 8860, host: 8860, auto_correct: true
@@ -82,7 +82,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    auth.vm.network "private_network", ip: "172.28.128.6"
+    auth.vm.network "private_network", ip: "172.28.128.106"
     auth.vm.network "forwarded_port", guest: 80, host: 8886, auto_correct: true
     auth.vm.synced_folder "../", "/vagrant-root"
     auth.vm.boot_timeout = 600

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -31,26 +31,10 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    regquery.vm.network "private_network", type: "dhcp"
-    regquery.vm.network "forwarded_port", type: "dhcp", guest: 80, host: 8882, auto_correct: true
+    regquery.vm.network "private_network", ip: "172.28.128.2"
+    regquery.vm.network "forwarded_port", guest: 80, host: 8882, auto_correct: true
     regquery.vm.synced_folder "../", "/vagrant-root"
     regquery.vm.boot_timeout = 600
-  end
-
-  config.vm.define "auth" do |auth|
-    auth.vm.hostname = "auth"
-    auth.vm.box = "bento/ubuntu-16.04"
-    auth.vm.provider "virtualbox" do |vb|
-      vb.gui = false
-      vb.linked_clone = true
-      vb.memory = 1024
-      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
-      vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
-    end
-    auth.vm.network "private_network", type: "dhcp"
-    auth.vm.network "forwarded_port", type: "dhcp", guest: 80, host: 8886, auto_correct: true
-    auth.vm.synced_folder "../", "/vagrant-root"
-    auth.vm.boot_timeout = 600
   end
 
   config.vm.define "node" do |node|
@@ -63,12 +47,28 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    node.vm.network "private_network", type: "dhcp"
-    node.vm.network "forwarded_port", type: "dhcp", guest: 80, host: 8884, auto_correct: true
-    node.vm.network "forwarded_port", type: "dhcp", guest: 8858, host: 8858, auto_correct: true
-    node.vm.network "forwarded_port", type: "dhcp", guest: 8860, host: 8859, auto_correct: true
+    node.vm.network "private_network", ip: "172.28.128.4"
+    node.vm.network "forwarded_port", guest: 80, host: 8884, auto_correct: true
+    node.vm.network "forwarded_port", guest: 8858, host: 8858, auto_correct: true
+    node.vm.network "forwarded_port", guest: 8860, host: 8860, auto_correct: true
     node.vm.synced_folder "../", "/vagrant-root"
     node.vm.boot_timeout = 600
+  end
+
+  config.vm.define "auth" do |auth|
+    auth.vm.hostname = "auth"
+    auth.vm.box = "bento/ubuntu-16.04"
+    auth.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.linked_clone = true
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
+    end
+    auth.vm.network "private_network", ip: "172.28.128.6"
+    auth.vm.network "forwarded_port", guest: 80, host: 8886, auto_correct: true
+    auth.vm.synced_folder "../", "/vagrant-root"
+    auth.vm.boot_timeout = 600
   end
 
   config.vm.define "testing" do |node|
@@ -81,8 +81,8 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    node.vm.network "private_network", type: "dhcp"
-    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 5000, auto_correct: true
+    node.vm.network "private_network", ip: "172.28.128.8"
+    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
     node.vm.synced_folder "../", "/vagrant-root"
     node.vm.boot_timeout = 600
   end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,20 +21,20 @@ Vagrant.configure("2") do |config|
   # keep SSH connection alive
   config.ssh.keep_alive = true
 
-  config.vm.define "testing" do |node|
-    node.vm.box = "bento/ubuntu-16.04"
-    node.vm.hostname = "testing"
-    node.vm.provider "virtualbox" do |vb|
+  config.vm.define "testing" do |testing|
+    testing.vm.box = "bento/ubuntu-16.04"
+    testing.vm.hostname = "testing"
+    testing.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.linked_clone = true
       vb.memory = 1024
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
-    node.vm.network "private_network", ip: "172.28.128.8"
-    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
-    node.vm.synced_folder "../", "/vagrant-root"
-    node.vm.boot_timeout = 600
+    testing.vm.network "private_network", ip: "172.28.128.8"
+    testing.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
+    testing.vm.synced_folder "../", "/vagrant-root"
+    testing.vm.boot_timeout = 600
   end
 >>>>>>> Make service file for testing tool use environment variables for proxy and allow testing tool time to start
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,13 +21,13 @@ Vagrant.configure("2") do |config|
   # keep SSH connection alive
   config.ssh.keep_alive = true
 
-  config.vm.define "regquery" do |regquery|	
+  config.vm.define "regquery" do |regquery|
     regquery.vm.hostname = "regquery"
     regquery.vm.box = "bento/ubuntu-16.04"
     regquery.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.linked_clone = true
-      vb.memory = 2048
+      vb.memory = 1024
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
@@ -37,13 +37,13 @@ Vagrant.configure("2") do |config|
     regquery.vm.boot_timeout = 600
   end
 
-  config.vm.define "auth" do |auth|	
+  config.vm.define "auth" do |auth|
     auth.vm.hostname = "auth"
     auth.vm.box = "bento/ubuntu-16.04"
     auth.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.linked_clone = true
-      vb.memory = 2048
+      vb.memory = 1024
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
     node.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.linked_clone = true
-      vb.memory = 2048
+      vb.memory = 1024
       vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
     end
@@ -71,9 +71,24 @@ Vagrant.configure("2") do |config|
     node.vm.boot_timeout = 600
   end
 
+  config.vm.define "testing" do |node|
+    node.vm.box = "bento/ubuntu-16.04"
+    node.vm.hostname = "testing"
+    node.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.linked_clone = true
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
+    end
+    node.vm.network "private_network", type: "dhcp"
+    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 5000, auto_correct: true
+    node.vm.synced_folder "../", "/vagrant-root"
+    node.vm.boot_timeout = 600
+  end
+
 # Provision each VM
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "provisioning/install_playbook.yml"
   end
 end
-

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,6 +21,23 @@ Vagrant.configure("2") do |config|
   # keep SSH connection alive
   config.ssh.keep_alive = true
 
+  config.vm.define "testing" do |node|
+    node.vm.box = "bento/ubuntu-16.04"
+    node.vm.hostname = "testing"
+    node.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.linked_clone = true
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
+    end
+    node.vm.network "private_network", ip: "172.28.128.8"
+    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
+    node.vm.synced_folder "../", "/vagrant-root"
+    node.vm.boot_timeout = 600
+  end
+>>>>>>> Make service file for testing tool use environment variables for proxy and allow testing tool time to start
+
   config.vm.define "regquery" do |regquery|
     regquery.vm.hostname = "regquery"
     regquery.vm.box = "bento/ubuntu-16.04"
@@ -69,22 +86,6 @@ Vagrant.configure("2") do |config|
     auth.vm.network "forwarded_port", guest: 80, host: 8886, auto_correct: true
     auth.vm.synced_folder "../", "/vagrant-root"
     auth.vm.boot_timeout = 600
-  end
-
-  config.vm.define "testing" do |node|
-    node.vm.box = "bento/ubuntu-16.04"
-    node.vm.hostname = "testing"
-    node.vm.provider "virtualbox" do |vb|
-      vb.gui = false
-      vb.linked_clone = true
-      vb.memory = 1024
-      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
-      vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on" ]
-    end
-    node.vm.network "private_network", ip: "172.28.128.8"
-    node.vm.network "forwarded_port", type: "dhcp", guest: 5000, host: 8888, auto_correct: true
-    node.vm.synced_folder "../", "/vagrant-root"
-    node.vm.boot_timeout = 600
   end
 
 # Provision each VM

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -36,7 +36,6 @@ Vagrant.configure("2") do |config|
     testing.vm.synced_folder "../", "/vagrant-root"
     testing.vm.boot_timeout = 600
   end
->>>>>>> Make service file for testing tool use environment variables for proxy and allow testing tool time to start
 
   config.vm.define "regquery" do |regquery|
     regquery.vm.hostname = "regquery"

--- a/vagrant/provisioning/group_vars/all
+++ b/vagrant/provisioning/group_vars/all
@@ -1,14 +1,14 @@
-common_packages_to_install: 
+common_packages_to_install:
     - package_name: "nmoscommon"
       repo_url: "https://github.com/bbc/nmos-common.git"
-      branch: "NMOS_RI_COMMON_BRANCH"
+      branch_envvar: "NMOS_RI_COMMON_BRANCH"
     - package_name: "nmosreverseproxy"
       repo_url: "https://github.com/bbc/nmos-reverse-proxy.git"
-      branch: "NMOS_RI_REVERSE_PROXY_BRANCH"
+      branch_envvar: "NMOS_RI_REVERSE_PROXY_BRANCH"
       service_file: "python3-nmosreverseproxy.service"
       reverse_proxy_file: "ips-reverseproxy-common.conf"
     - package_name: "mdnsbridge"
       repo_url: "https://github.com/bbc/nmos-mdns-bridge.git"
-      branch: "NMOS_RI_MDNS_BRIDGE_BRANCH"
+      branch_envvar: "NMOS_RI_MDNS_BRIDGE_BRANCH"
       service_file: "python3-mdnsbridge.service"
       reverse_proxy_file: "ips-api-mdnsbridge.conf"

--- a/vagrant/provisioning/host_vars/auth
+++ b/vagrant/provisioning/host_vars/auth
@@ -1,7 +1,7 @@
 
-specific_packages_to_install: 
+specific_packages_to_install:
     - package_name: "nmos-auth"
       repo_url: "https://github.com/bbc/nmos-auth-server.git"
-      branch: "NMOS_RI_AUTH_BRANCH"
+      branch_envvar: "NMOS_RI_AUTH_BRANCH"
       service_file: "python3-nmos-auth.service"
       reverse_proxy_file: "ips-api-auth.conf"

--- a/vagrant/provisioning/host_vars/node
+++ b/vagrant/provisioning/host_vars/node
@@ -1,12 +1,12 @@
 
-specific_packages_to_install: 
+specific_packages_to_install:
     - package_name: "nodefacade"
       repo_url: "https://github.com/bbc/nmos-node.git"
-      branch: "NMOS_RI_NODE_BRANCH"
+      branch_envvar: "NMOS_RI_NODE_BRANCH"
       service_file: "python3-nodefacade.service"
       reverse_proxy_file: "ips-api-node.conf"
     - package_name: "connectionmanagement"
       repo_url: "https://github.com/bbc/nmos-device-connection-management-ri.git"
-      branch: "NMOS_RI_CONNECTION_BRANCH"
+      branch_envvar: "NMOS_RI_CONNECTION_BRANCH"
       service_file: "python3-connectionmanagement.service"
       reverse_proxy_file: "nmos-api-nmosconnection.conf"

--- a/vagrant/provisioning/host_vars/regquery
+++ b/vagrant/provisioning/host_vars/regquery
@@ -1,14 +1,14 @@
 
-specific_packages_to_install: 
+specific_packages_to_install:
     - package_name: "registryaggregator"
       repo_url: "https://github.com/bbc/nmos-registration.git"
-      branch: "NMOS_RI_REGISTRATION_BRANCH"
+      branch_envvar: "NMOS_RI_REGISTRATION_BRANCH"
       service_file: "python3-registryaggregator.service"
       reverse_proxy_file: "ips-api-registration.conf"
-      required_debs: 
+      required_debs:
         - etcd
     - package_name: "registryquery"
       repo_url: "https://github.com/bbc/nmos-query.git"
-      branch: "NMOS_RI_QUERY_BRANCH"
+      branch_envvar: "NMOS_RI_QUERY_BRANCH"
       service_file: "python3-registryquery.service"
       reverse_proxy_file: "ips-api-query.conf"

--- a/vagrant/provisioning/host_vars/testing
+++ b/vagrant/provisioning/host_vars/testing
@@ -2,4 +2,4 @@
 specific_packages_to_install:
     - package_name: "nmos-testing"
       repo_url: "https://github.com/AMWA-TV/nmos-testing"
-      branch: "NMOS_RI_TESTING_BRANCH"
+      branch_envvar: "NMOS_RI_TESTING_BRANCH"

--- a/vagrant/provisioning/host_vars/testing
+++ b/vagrant/provisioning/host_vars/testing
@@ -1,0 +1,5 @@
+
+specific_packages_to_install:
+    - package_name: "nmos-testing"
+      repo_url: "https://github.com/AMWA-TV/nmos-testing"
+      branch: "NMOS_RI_TESTING_BRANCH"

--- a/vagrant/provisioning/install_playbook.yml
+++ b/vagrant/provisioning/install_playbook.yml
@@ -17,8 +17,8 @@
         package_name: "{{ item.package_name }}"
         repo_url: "{{ item.repo_url }}"
         branch: "{{ lookup('env', item.branch) | default('master', true) }}"
-        service_file: "{{ item.service_file|default([]) }}"
-        reverse_proxy_file: "{{ item.reverse_proxy_file|default([]) }}"
+        service_file: "{{ item.service_file | default([]) }}"
+        reverse_proxy_file: "{{ item.reverse_proxy_file | default([]) }}"
         required_debs: "{{ item.required_debs | default([]) }}"
       with_items: "{{ common_packages_to_install + specific_packages_to_install }}"
 

--- a/vagrant/provisioning/install_playbook.yml
+++ b/vagrant/provisioning/install_playbook.yml
@@ -16,7 +16,7 @@
       vars:
         package_name: "{{ item.package_name }}"
         repo_url: "{{ item.repo_url }}"
-        branch: "{{ lookup('env', item.branch) | default('master', true) }}"
+        branch: "{{ lookup('env', item.branch_envvar) | default('master', true) }}"
         service_file: "{{ item.service_file | default([]) }}"
         reverse_proxy_file: "{{ item.reverse_proxy_file | default([]) }}"
         required_debs: "{{ item.required_debs | default([]) }}"

--- a/vagrant/provisioning/roles/nmos-joint-ri-setup/tasks/main.yml
+++ b/vagrant/provisioning/roles/nmos-joint-ri-setup/tasks/main.yml
@@ -3,18 +3,19 @@
 # description: Provision NMOS Joint RI VM
 
 - name: Install all required packages for nmos-joint-ri-setup
-  apt: 
+  apt:
     pkg: "{{ packages }}"
     state: present
+    update_cache: yes
 
 - name: Install Apache2 modules
   apache2_module:
     state: present
     name: "{{ item }}"
   with_items: "{{ apache_modules }}"
-    
+
 - name: Remove default Apache conf files
-  file: 
+  file:
     path: "{{ item }}"
     state: absent
   with_items:

--- a/vagrant/provisioning/roles/nmos-joint-ri-setup/tasks/main.yml
+++ b/vagrant/provisioning/roles/nmos-joint-ri-setup/tasks/main.yml
@@ -3,19 +3,18 @@
 # description: Provision NMOS Joint RI VM
 
 - name: Install all required packages for nmos-joint-ri-setup
-  apt:
+  apt: 
     pkg: "{{ packages }}"
     state: present
-    update_cache: yes
 
 - name: Install Apache2 modules
   apache2_module:
     state: present
     name: "{{ item }}"
   with_items: "{{ apache_modules }}"
-
+    
 - name: Remove default Apache conf files
-  file:
+  file: 
     path: "{{ item }}"
     state: absent
   with_items:

--- a/vagrant/provisioning/roles/nmos-service-install/tasks/main.yml
+++ b/vagrant/provisioning/roles/nmos-service-install/tasks/main.yml
@@ -6,5 +6,7 @@
   include_tasks: package_install.yml
 - name: reverse_proxy
   include_tasks: reverse_proxy.yml
+- name: testing_tool
+  include_tasks: testing_tool.yml
 - name: service_install
   include_tasks: service_install.yml

--- a/vagrant/provisioning/roles/nmos-service-install/tasks/package_install.yml
+++ b/vagrant/provisioning/roles/nmos-service-install/tasks/package_install.yml
@@ -7,7 +7,7 @@
     var: package_name
 
 - name: Install required debian packages
-  apt: 
+  apt:
     pkg: "{{ required_debs }}"
     state: present
 
@@ -18,7 +18,7 @@
     version: "{{ branch }}"
 
 - name: Create NMOS log file for nmoscommon
-  file: 
+  file:
     path: /var/log/nmos.log
     owner: ipstudio
     group: ipstudio
@@ -32,7 +32,7 @@
   when: package_name == "nmoscommon"
 
 - name: Create nmoscommon config file
-  template: 
+  template:
     src: nmoscommon_config.j2
     dest: /etc/nmoscommon/config.json
   when: package_name == "nmoscommon"

--- a/vagrant/provisioning/roles/nmos-service-install/tasks/service_install.yml
+++ b/vagrant/provisioning/roles/nmos-service-install/tasks/service_install.yml
@@ -1,6 +1,6 @@
 ---
 # module: nmos-service-install/tasks
-# description: Install NMOS systemd service 
+# description: Install NMOS systemd service
 
 - name: Create service file
   copy:
@@ -8,6 +8,12 @@
     dest: /lib/systemd/system
     remote_src: yes
   when: service_file != []
+
+- name: Make Testing Tool Service File
+  template:
+    src: systemd_service.j2
+    dest: /lib/systemd/system/python3-nmos-testing.service
+  when: package_name == "nmos-testing"
 
 - name: Change directory permissions for nmosauth config files
   file:
@@ -24,3 +30,11 @@
     enabled: true
     daemon_reload: true
   when: service_file != []
+
+- name: Restart Testing Tool service
+  systemd:
+    name: python3-nmos-testing.service
+    state: restarted
+    enabled: true
+    daemon_reload: true
+  when: package_name == "nmos-testing"

--- a/vagrant/provisioning/roles/nmos-service-install/tasks/testing_tool.yml
+++ b/vagrant/provisioning/roles/nmos-service-install/tasks/testing_tool.yml
@@ -1,0 +1,26 @@
+---
+- name: Change ownership of nmos-testing directory
+  file:
+    path: /home/vagrant/nmos-testing
+    owner: "{{ ansible_facts['env']['SUDO_USER'] }}"
+    group: "{{ ansible_facts['env']['SUDO_USER'] }}"
+    state: directory
+    recurse: yes
+
+- name: Upgrade pip3
+  command: pip3 install --upgrade pip
+  when: package_name == "nmos-testing"
+
+- name: Install Requirements
+  command: pip3 install -r requirements.txt
+  args:
+    chdir: "/home/{{ ansible_facts['env']['SUDO_USER'] }}/{{ package_name }}"
+  when: package_name == "nmos-testing"
+
+# - name: Run Testing Tool
+#   command: sudo python3 nmos-test.py
+#   args:
+#     chdir: "/home/{{ ansible_facts['env']['SUDO_USER'] }}/{{ package_name }}"
+#   when: package_name == "nmos-testing"
+#   async: 10
+#   poll: 0

--- a/vagrant/provisioning/roles/nmos-service-install/templates/systemd_service.j2
+++ b/vagrant/provisioning/roles/nmos-service-install/templates/systemd_service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ package_name }}
+Wants=network-online.target apache2.service
+After=network.target network-online.target apache2.service
+
+[Service]
+WorkingDirectory=/home/{{ ansible_facts['env']['SUDO_USER'] }}/{{ package_name }}
+User={{ ansible_facts['env']['SUDO_USER'] }}
+Restart=always
+RestartSec=3
+ExecStart=/usr/bin/python3 /home/{{ ansible_facts['env']['SUDO_USER'] }}/{{ package_name }}/nmos-test.py
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/provisioning/roles/nmos-service-install/templates/systemd_service.j2
+++ b/vagrant/provisioning/roles/nmos-service-install/templates/systemd_service.j2
@@ -5,6 +5,7 @@ After=network.target network-online.target apache2.service
 
 [Service]
 WorkingDirectory=/home/{{ ansible_facts['env']['SUDO_USER'] }}/{{ package_name }}
+EnvironmentFile=/etc/environment
 User={{ ansible_facts['env']['SUDO_USER'] }}
 Restart=always
 RestartSec=3


### PR DESCRIPTION
This PR adds:
- A new vagrant box to host the testing tool
- ansible to clone the testing tool and run the test as a service
- integration tests to fire the testing tool off for IS-04, IS-05 and IS-10 tests

When testing remember to add an env var:
` export NMOS_RI_TESTING_BRANCH="dannym-api" `